### PR TITLE
Fix booking status handling

### DIFF
--- a/bookings/permissions.py
+++ b/bookings/permissions.py
@@ -25,7 +25,7 @@ class BookingPermission(permissions.BasePermission):
 
         if user.role == 'landlord':
             # Может подтвердить или отклонить бронь для своего объекта
-            if view.action == 'partial_update':
+            if view.action in ['partial_update', 'confirm', 'decline']:
                 return obj.listing.owner == user
 
         return False

--- a/bookings/views.py
+++ b/bookings/views.py
@@ -40,16 +40,16 @@ class BookingViewSet(viewsets.ModelViewSet):
         if request.user != booking.listing.owner:
             return Response({"detail": "Недостаточно прав."}, status=status.HTTP_403_FORBIDDEN)
 
-        booking.status = 'declined'
+        booking.status = 'rejected'
         booking.save()
-        return Response({'status': 'declined'}, status=status.HTTP_200_OK)
+        return Response({'status': 'rejected'}, status=status.HTTP_200_OK)
 
 class BookingStatusUpdateView(APIView):
     permission_classes = [permissions.IsAuthenticated]
 
     def patch(self, request, pk):
         status_value = request.data.get("status")
-        if status_value not in ["pending", "accepted", "declined"]:
+        if status_value not in ["pending", "confirmed", "canceled", "rejected"]:
             return Response({"error": "Неверный статус"}, status=status.HTTP_400_BAD_REQUEST)
 
         try:


### PR DESCRIPTION
## Summary
- handle confirm/decline permissions correctly
- use the correct booking status constants

## Testing
- `python manage.py test` *(fails: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_683f7302d9a08332b16e98c32afff325